### PR TITLE
linux-mingw: Perform a full-upgrade like on linux-fresh and linux-clang-format

### DIFF
--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:18.04
 MAINTAINER yuzu
 RUN useradd -m -s /bin/bash yuzu && mkdir -p /tmp/pkgs
-RUN apt-get update && apt-get install -y gpg wget git python3-pip python ccache p7zip-full g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64 mingw-w64-tools cmake ninja-build
+RUN apt-get update && apt-get -y full-upgrade
+RUN apt-get install -y gpg wget git python3-pip python ccache p7zip-full g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64 mingw-w64-tools cmake ninja-build
 # workaround broken headers in Ubuntu MinGW package
 COPY errno.h /usr/x86_64-w64-mingw32/include/
 # add mingw-w64 auxiliary ppa repository


### PR DESCRIPTION
This brings parity between linux-mingw, linux-fresh and linux-clang-format.