### PR TITLE
Revert "Set mingw SDL2 version to 2.0.10"

### DIFF
--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -7,6 +7,6 @@ COPY errno.h /usr/x86_64-w64-mingw32/include/
 # add mingw-w64 auxiliary ppa repository
 RUN echo 'deb http://ppa.launchpad.net/tobydox/mingw-w64/ubuntu bionic main ' > /etc/apt/sources.list.d/extras.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv '72931B477E22FEFD47F8DECE02FE5F12ADDE29B2' && apt-get update
-RUN apt-get install -y qt5base-mingw-w64 qt5tools-mingw-w64 libsamplerate-mingw-w64 qt5multimedia-mingw-w64
+RUN apt-get install -y sdl2-mingw-w64 qt5base-mingw-w64 qt5tools-mingw-w64 libsamplerate-mingw-w64 qt5multimedia-mingw-w64
 COPY mingw-setup.sh /tmp/pkgs
 RUN cd /tmp/pkgs && bash -e mingw-setup.sh

--- a/linux-mingw/mingw-setup.sh
+++ b/linux-mingw/mingw-setup.sh
@@ -10,14 +10,6 @@ wget -q "${MINGW_URL}" -O 'mingw.7z'
 7z x 'mingw.7z' "${TARGET_DIR}"lib{mf,mfplat,mfuuid}.a
 cp -rv "${TARGET_DIR}"/* '/usr/x86_64-w64-mingw32/lib/'
 
-# SDL2
-SDL2_VER='2.0.10'
-wget "https://www.libsdl.org/release/SDL2-devel-${SDL2_VER}-mingw.tar.gz"
-tar -zxf "SDL2-devel-${SDL2_VER}-mingw.tar.gz"
-cd SDL2-${SDL2_VER}/
-make install-package arch=x86_64-w64-mingw32 prefix=/usr/x86_64-w64-mingw32;
-cd ..
-
 # ffmpeg
 FFMPEG_VER='4.1'
 for i in 'shared' 'dev'; do


### PR DESCRIPTION
Reverts yuzu-emu/build-environments#5.
I need to take a look at this later. For now, this unblocks our Windows CI.