### PR TITLE
Add Dockerfile for linux-flatpak

### DIFF
--- a/linux-flatpak/Dockerfile
+++ b/linux-flatpak/Dockerfile
@@ -1,9 +1,16 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 MAINTAINER yuzu
 
-RUN useradd -m -s /bin/bash yuzu
-RUN apt-get update && apt-get -y full-upgrade && apt-get install --no-install-recommends -y flatpak flatpak-builder ca-certificates
-RUN flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-RUN flatpak install -v -y flathub org.kde.Platform//5.13 org.kde.Sdk//5.13
-RUN apt-get install --no-install-recommends -y build-essential libsdl2-dev libssl-dev python qtbase5-dev qtwebengine5-dev libqt5opengl5-dev wget git ccache cmake ninja-build dnsutils gnupg2 sshfs fuse elfutils
- 
+RUN useradd -m -s /bin/bash yuzu && DEBIAN_FRONTEND=noninteractive apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -y full-upgrade \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+        flatpak flatpak-builder \
+        librsvg2-common \
+        ca-certificates build-essential libsdl2-dev libssl-dev \
+        python qtbase5-dev qtwebengine5-dev libqt5opengl5-dev \
+        wget git ccache cmake \
+        ninja-build dnsutils gnupg2 \
+        sshfs fuse elfutils \
+    && rm -Rf /var/lib/apt/lists/* \
+    && flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo \
+    && flatpak install -v -y flathub org.kde.Platform//5.13 org.kde.Sdk//5.13

--- a/linux-flatpak/Dockerfile
+++ b/linux-flatpak/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:18.04
+MAINTAINER yuzu
+
+RUN useradd -m -s /bin/bash yuzu
+RUN apt-get update && apt-get -y full-upgrade && apt-get install --no-install-recommends -y flatpak flatpak-builder ca-certificates
+RUN flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+RUN flatpak install -v -y flathub org.kde.Platform//5.13 org.kde.Sdk//5.13
+RUN apt-get install --no-install-recommends -y build-essential libsdl2-dev libssl-dev python qtbase5-dev qtwebengine5-dev libqt5opengl5-dev wget git ccache cmake ninja-build dnsutils gnupg2 sshfs fuse elfutils
+ 


### PR DESCRIPTION
Based on Citra's linux-flatpak Dockerfile ([here](https://github.com/citra-emu/build-environments/blob/master/linux-flatpak/Dockerfile)), abderrahim's flatpak Dockerfile from PR #4 and yuzu's linux-fresh Dockerfile ([here](https://github.com/yuzu-emu/build-environments/blob/master/linux-fresh/Dockerfile)).

Should be published as yuzuemu/build-environments:linux-flatpak