### PR TITLE
Add new system libraries and install some additional libraries through conan

### DIFF
--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -4,16 +4,27 @@ RUN useradd -m -s /bin/bash yuzu && \
     DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y full-upgrade && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     build-essential \
+    libboost-all-dev \
     libsdl2-dev \
     libssl-dev \
+    libopus-dev \
+    libzstd-dev \
     python \
+    python3-pip \
     qtbase5-dev \
     qtbase5-private-dev \
     qtwebengine5-dev \
     libqt5opengl5-dev \
+    liblz4-dev \
+    zlib1g-dev \
     wget \
     git \
     ccache \
     cmake \
     ninja-build && \
+    pip3 install conan && \
     apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log
+USER yuzu
+RUN conan install catch2/2.11.0@ && \
+    conan install fmt/6.2.0@ && \
+    conan install nlohmann_json/3.7.3@

--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -5,18 +5,19 @@ RUN useradd -m -s /bin/bash yuzu && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     build-essential \
     libboost-all-dev \
+    liblz4-dev \
     libsdl2-dev \
     libssl-dev \
     libopus-dev \
+    libzip-dev \
     libzstd-dev \
+    zlib1g-dev \
     python \
     python3-pip \
     qtbase5-dev \
     qtbase5-private-dev \
     qtwebengine5-dev \
     libqt5opengl5-dev \
-    liblz4-dev \
-    zlib1g-dev \
     wget \
     git \
     ccache \
@@ -25,6 +26,6 @@ RUN useradd -m -s /bin/bash yuzu && \
     pip3 install conan && \
     apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log
 USER yuzu
-RUN conan install catch2/2.11.0@ && \
-    conan install fmt/6.2.0@ && \
-    conan install nlohmann_json/3.7.3@
+RUN conan install catch2/2.11.0@ -s compiler.libcxx=libstdc++11 --build=missing && \
+    conan install fmt/6.2.0@ -s compiler.libcxx=libstdc++11 --build=missing && \
+    conan install nlohmann_json/3.7.3@ -s compiler.libcxx=libstdc++11 --build=missing

--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -1,6 +1,8 @@
 FROM archlinux:latest
 MAINTAINER yuzu
 # Add mingw-repo "ownstuff" is a AUR with an up to date mingw64
+# Runs pacman -Syu twice in order to work around pacman issues where the first run only updates the current distro packages
+# and the second run actually pulls the updates from the repos.
 RUN useradd -m -s /bin/bash yuzu && mkdir -p /tmp/pkgs && \
     echo "[ownstuff]" >> /etc/pacman.conf && \
     echo "SigLevel = Optional TrustAll" >> /etc/pacman.conf && \
@@ -14,28 +16,40 @@ RUN useradd -m -s /bin/bash yuzu && mkdir -p /tmp/pkgs && \
     git \
     python-pip \
     python \
+    python2 \
     ccache \
     p7zip \
     cmake \
     ninja \
+    mingw-w64-boost \
     mingw-w64-gcc \
-    mingw-w64-tools \
-    mingw-w64-sdl2 \
+    mingw-w64-lz4 \
+    mingw-w64-opus \
     mingw-w64-qt5-base \
     mingw-w64-qt5-tools \
     mingw-w64-qt5-graphicaleffects \
     mingw-w64-qt5-multimedia \
     mingw-w64-qt5-winextras \
-    python2 \
-    mingw-w64-opus \
-    mingw-w64-winpthreads && \
+    mingw-w64-sdl2 \
+    mingw-w64-tools \
+    mingw-w64-winpthreads \
+    mingw-w64-zlib \
+    mingw-w64-zstd \
+    && \
     pacman -Scc --noconfirm && \
     rm -rf /usr/share/man/ /tmp/ /var/tmp/
 
+# Setup extra mingw work arounds
 COPY mingw-setup.sh /tmp/
 RUN cd /tmp/ && bash -e mingw-setup.sh
 # Compatibility with the old Ubuntu MingW image
 RUN ln -s /usr/x86_64-w64-mingw32/lib/qt /usr/x86_64-w64-mingw32/lib/qt5
 
-# Cleanup
-USER root
+# Install conan and add the mingw cross compile as the default profile
+RUN pip3 install conan
+COPY --chown=yuzu:yuzu default /home/yuzu/.conan/profiles/
+USER yuzu
+# Install/build the missing libs (uses the default mingw cross compile profile)
+RUN conan install catch2/2.11.0@ --build=missing && \
+    conan install fmt/6.2.0@ --build=missing && \
+    conan install nlohmann_json/3.7.3@ --build=missing

--- a/linux-mingw/default
+++ b/linux-mingw/default
@@ -1,0 +1,26 @@
+toolchain=/usr/x86_64-w64-mingw32
+target_host=x86_64-w64-mingw32
+cc_compiler=gcc
+cxx_compiler=g++
+
+[env]
+CONAN_CMAKE_FIND_ROOT_PATH=$toolchain
+CHOST=$target_host
+AR=$target_host-ar
+AS=$target_host-as
+RANLIB=$target_host-ranlib
+CC=$target_host-$cc_compiler
+CXX=$target_host-$cxx_compiler
+STRIP=$target_host-strip
+RC=$target_host-windres
+
+[settings]
+# We are cross-building to Windows
+os=Windows
+arch=x86_64
+compiler=gcc
+
+# Adjust to the gcc version of your MinGW package
+compiler.version=9
+compiler.libcxx=libstdc++11
+build_type=Release


### PR DESCRIPTION
As a required change for https://github.com/yuzu-emu/yuzu/pull/3735 this updates the docker container to have additional dependencies installed through the package manager and through conan, that were previously vendored in the externals folder in yuzu. 

New system packages installed that were originally in externals:
* Boost - libboost-all-dev 
* Opus - libopus-dev 
* zstd - libzstd-dev 
* lz4 - liblz4-dev 
* zlib - zlib1g-dev 
* libzip - libzip-dev

New conan packages installed for the yuzu user:
* catch2/2.11.0
* fmt/6.2.0
* nlohmann_json/3.7.3

New misc packages added:
* python3-pip  - Needed to install conan

This PR also fixes up mingw cross compiling and sets up conan for cross compiling.

New system package installed for mingw:
* mingw-w64-boost 
* mingw-w64-lz4 
* mingw-w64-zlib 
* mingw-w64-zstd 