### PR TITLE
Update the docker images to run as yuzu user (UID 1027)

### DIFF
--- a/linux-clang-format/Dockerfile
+++ b/linux-clang-format/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:20.04
 MAINTAINER yuzu
-RUN useradd -m -s /bin/bash yuzu && \
+# Create a user account yuzu (UID 1027) that the container will run as
+RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     apt-get update && apt-get -y full-upgrade && \
     apt-get install -y git clang-format-6.0 && \
     apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log
+USER 1027

--- a/linux-flatpak/Dockerfile
+++ b/linux-flatpak/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:20.04
 MAINTAINER yuzu
-
-RUN useradd -m -s /bin/bash yuzu && DEBIAN_FRONTEND=noninteractive apt-get update \
+RUN useradd -m -u 1027 -s /bin/bash yuzu && DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get -y full-upgrade \
     && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         flatpak flatpak-builder \
@@ -11,6 +10,7 @@ RUN useradd -m -s /bin/bash yuzu && DEBIAN_FRONTEND=noninteractive apt-get updat
         wget git ccache cmake \
         ninja-build dnsutils gnupg2 \
         sshfs fuse elfutils \
-    && rm -Rf /var/lib/apt/lists/* \
+    && apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log \
     && flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo \
     && flatpak install -v -y flathub org.kde.Platform//5.13 org.kde.Sdk//5.13
+USER 1027

--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:20.04
 MAINTAINER yuzu
-RUN useradd -m -s /bin/bash yuzu && \
+# Create a user account yuzu (UID 1027) that the container will run as
+RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y full-upgrade && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     build-essential \
@@ -25,7 +26,7 @@ RUN useradd -m -s /bin/bash yuzu && \
     ninja-build && \
     pip3 install conan && \
     apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log
-USER yuzu
+USER 1027
 RUN conan install catch2/2.11.0@ -s compiler.libcxx=libstdc++11 --build=missing && \
     conan install fmt/6.2.0@ -s compiler.libcxx=libstdc++11 --build=missing && \
     conan install nlohmann_json/3.7.3@ -s compiler.libcxx=libstdc++11 --build=missing

--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER yuzu
 # Add mingw-repo "ownstuff" is a AUR with an up to date mingw64
 # Runs pacman -Syu twice in order to work around pacman issues where the first run only updates the current distro packages
 # and the second run actually pulls the updates from the repos.
-RUN useradd -m -s /bin/bash yuzu && mkdir -p /tmp/pkgs && \
+RUN useradd -m -u 1027 -s /bin/bash yuzu && mkdir -p /tmp/pkgs && \
     echo "[ownstuff]" >> /etc/pacman.conf && \
     echo "SigLevel = Optional TrustAll" >> /etc/pacman.conf && \
     echo "Server = https://martchus.no-ip.biz/repo/arch/ownstuff/os/\$arch" >> /etc/pacman.conf && \
@@ -48,7 +48,7 @@ RUN ln -s /usr/x86_64-w64-mingw32/lib/qt /usr/x86_64-w64-mingw32/lib/qt5
 # Install conan and add the mingw cross compile as the default profile
 RUN pip3 install conan
 COPY --chown=yuzu:yuzu default /home/yuzu/.conan/profiles/
-USER yuzu
+USER 1027
 # Install/build the missing libs (uses the default mingw cross compile profile)
 RUN conan install catch2/2.11.0@ --build=missing && \
     conan install fmt/6.2.0@ --build=missing && \

--- a/linux-transifex/Dockerfile
+++ b/linux-transifex/Dockerfile
@@ -1,10 +1,11 @@
 FROM alpine
 MAINTAINER yuzu
-RUN adduser -u 1000 -D -s /bin/bash yuzu && \
-    apk update && apk add build-base && \
+RUN adduser -u 1027 -D -s /bin/bash yuzu && \
+    apk update && apk add build-base \
     cmake \
     python3-dev \
     qt5-qttools-dev \
     qt5-qtmultimedia-dev && \
     pip3 install transifex-client && \
-    apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log/
+    rm -rf /var/cache/apk/*
+USER 1027


### PR DESCRIPTION
This changes the script to use the `yuzu` user for anyone that runs the image. As a docker best practice, containers should try to only run as an unprivileged user https://docs.docker.com/engine/security/userns-remap/ to prevent privilege escalation attacks.

Also fixed a few small issues that crept in in the previous commits.