### PR TITLE
Use nlohmann json from ubuntu and avoid boost-all.

### DIFF
--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -5,20 +5,22 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y full-upgrade && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     build-essential \
-    libboost-all-dev \
+    libboost-dev \
+    libboost-context-dev \
     liblz4-dev \
+    libopus-dev \
+    libqt5opengl5-dev \
     libsdl2-dev \
     libssl-dev \
-    libopus-dev \
     libzip-dev \
     libzstd-dev \
-    zlib1g-dev \
+    nlohmann-json3-dev \
     python \
     python3-pip \
     qtbase5-dev \
     qtbase5-private-dev \
     qtwebengine5-dev \
-    libqt5opengl5-dev \
+    zlib1g-dev \
     wget \
     git \
     ccache \
@@ -28,5 +30,4 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log
 USER 1027
 RUN conan install catch2/2.11.0@ -s compiler.libcxx=libstdc++11 --build=missing && \
-    conan install fmt/6.2.0@ -s compiler.libcxx=libstdc++11 --build=missing && \
-    conan install nlohmann_json/3.7.3@ -s compiler.libcxx=libstdc++11 --build=missing
+    conan install fmt/6.2.0@ -s compiler.libcxx=libstdc++11 --build=missing


### PR DESCRIPTION
I like to prefer ubuntu repository over conan, but that's a minor change.
However boost-all is just huge, so we can skip it.