### PR TITLE
clang-format: Correct package name

### DIFF
--- a/linux-clang-format/Dockerfile
+++ b/linux-clang-format/Dockerfile
@@ -3,6 +3,6 @@ MAINTAINER yuzu
 # Create a user account yuzu (UID 1027) that the container will run as
 RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     apt-get update && apt-get -y full-upgrade && \
-    apt-get install -y git clang-format-10.0 && \
+    apt-get install -y git clang-format-10 && \
     apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log
 USER 1027


### PR DESCRIPTION
The actual [package](https://packages.ubuntu.com/focal/clang-format-10) itself has dropped the use of the decimal in the version number.