### PR TITLE
Make use of up to date libraries on the buildbots

### DIFF
--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -28,6 +28,6 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     pip3 install conan && \
     apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log
 USER 1027
-RUN conan install catch2/2.11.0@ -s compiler.libcxx=libstdc++11 --build=missing && \
-    conan install fmt/6.2.0@ -s compiler.libcxx=libstdc++11 --build=missing && \
-    conan install nlohmann_json/3.7.3@ -s compiler.libcxx=libstdc++11 --build=missing
+RUN conan install catch2/2.13.0@ -s compiler.libcxx=libstdc++11 --build=missing && \
+    conan install fmt/7.0.3@ -s compiler.libcxx=libstdc++11 --build=missing && \
+    conan install nlohmann_json/3.9.1@ -s compiler.libcxx=libstdc++11 --build=missing

--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -50,6 +50,6 @@ RUN pip3 install conan
 COPY --chown=yuzu:yuzu default /home/yuzu/.conan/profiles/
 USER 1027
 # Install/build the missing libs (uses the default mingw cross compile profile)
-RUN conan install catch2/2.11.0@ --build=missing && \
-    conan install fmt/6.2.0@ --build=missing && \
-    conan install nlohmann_json/3.7.3@ --build=missing
+RUN conan install catch2/2.13.0@ --build=missing && \
+    conan install fmt/7.0.3@ --build=missing && \
+    conan install nlohmann_json/3.9.1@ --build=missing


### PR DESCRIPTION
Ensures that the docker containers use more up to date versions of the libraries that we install from conan.