### PR TITLE
linux-flatpak: Update runtime version to 5.15

### DIFF
--- a/linux-flatpak/Dockerfile
+++ b/linux-flatpak/Dockerfile
@@ -12,5 +12,5 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && DEBIAN_FRONTEND=noninteractive apt-g
         sshfs fuse elfutils \
     && apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log \
     && flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo \
-    && flatpak install -v -y flathub org.kde.Platform//5.13 org.kde.Sdk//5.13
+    && flatpak install -v -y flathub org.kde.Platform//5.15 org.kde.Sdk//5.15
 USER 1027


### PR DESCRIPTION
Required for the glslangValidator command, introduced in yuzu-emu/yuzu#4967.