### PR TITLE
linux-fresh: Install Boost through Conan

### DIFF
--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -11,7 +11,6 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     libavcodec-dev \
     libavutil-dev \
     libswscale-dev \
-    libboost-all-dev \
     liblz4-dev \
     libopus-dev \
     libsdl2-dev \
@@ -38,6 +37,7 @@ RUN apt-get clean autoclean && \
     apt-get autoremove --yes && \
     rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log
 USER 1027
-RUN conan install catch2/2.13.0@ -s compiler.libcxx=libstdc++11 --build=missing && \
+RUN conan install boost/1.73.0@ -s compiler.libcxx=libstdc++11 --build=missing && \
+    conan install catch2/2.13.0@ -s compiler.libcxx=libstdc++11 --build=missing && \
     conan install fmt/7.1.2@ -s compiler.libcxx=libstdc++11 --build=missing && \
     conan install nlohmann_json/3.9.1@ -s compiler.libcxx=libstdc++11 --build=missing


### PR DESCRIPTION
Ubuntu 20.04's version of Boost (1.71.0) is older than yuzu's minimum requirement (1.73.0). Thus the container was downloading Boost through Conan each time it builds yuzu.

Instead, install Boost through Conan ahead of time, as opposed to installing effectively garbage.