### PR TITLE
linux-fresh: Downgrade to Bionic Beaver

### DIFF
--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -1,41 +1,70 @@
-FROM ubuntu:20.04
+FROM ubuntu:18.04
 MAINTAINER yuzu
+
+ENV CMAKE_VER=3.16.3
+ENV GCC_VER=10
+ENV QT_PKG_VER=512
+ENV QT_VER=5.12.6
+ENV UBUNTU_VER=bionic
+
 # Create a user account yuzu (UID 1027) that the container will run as
 RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y full-upgrade && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     build-essential \
-    gcc-10 \
-    g++-10 \
-    glslang-tools \
-    libavcodec-dev \
-    libavutil-dev \
-    libswscale-dev \
+    ccache \
+    file \
+    git \
     liblz4-dev \
     libopus-dev \
-    libsdl2-dev \
     libssl-dev \
     libzip-dev \
     libzstd-dev \
-    zlib1g-dev \
-    python \
+    ninja-build \
     python3-pip \
-    qtbase5-dev \
-    qtbase5-private-dev \
-    qttools5-dev \
-    qtwebengine5-dev \
-    libqt5opengl5-dev \
+    python3-setuptools \
+    software-properties-common \
+    unzip \
     wget \
-    git \
-    ccache \
-    cmake \
-    ninja-build && \
+    zlib1g-dev && \
     pip3 install conan
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10 && \
-    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
-RUN apt-get clean autoclean && \
+# Install updated versions of FFmpeg, GCC, Qt, and SDL2 from launchpad repositories
+RUN add-apt-repository -y ppa:beineri/opt-qt-${QT_VER}-${UBUNTU_VER} && \
+    add-apt-repository -y ppa:cybermax-dexter/sdl2-backport && \
+    add-apt-repository -y ppa:jonathonf/ffmpeg-4 && \
+    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+    apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    g++-${GCC_VER} \
+    gcc-${GCC_VER} \
+    libavcodec-dev \
+    libavutil-dev \
+    libsdl2-dev \
+    libswscale-dev \
+    qt${QT_PKG_VER}base \
+    qt${QT_PKG_VER}tools \
+    qt${QT_PKG_VER}webengine && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VER} ${GCC_VER} && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VER} ${GCC_VER} && \
+    apt-get clean autoclean && \
     apt-get autoremove --yes && \
     rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log
+# Install glslangValidator from upstream
+# glslangValidator is not available from Ubuntu's Bionic repositories.
+RUN cd /tmp && \
+    wget https://github.com/KhronosGroup/glslang/releases/download/master-tot/glslang-master-linux-Release.zip && \
+    unzip glslang-master-linux-Release.zip -d /usr && \
+    rm -v glslang-master-linux-Release.zip
+# Install CMake from upstream
+# yuzu requires CMake version 3.15, however Ubuntu only provides 3.10 to Bionic.
+RUN cd /tmp && \
+    wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-Linux-x86_64.tar.gz && \
+    tar xvf cmake-${CMAKE_VER}-Linux-x86_64.tar.gz && \
+    cp -rv cmake-${CMAKE_VER}-Linux-x86_64/* /usr && \
+    rm -rf cmake-*
+# Setup paths for Qt binaries
+ENV LD_LIBRARY_PATH=/opt/qt${QT_PKG_VER}/lib:${LD_LIBRARY_PATH}
+ENV PATH=/opt/qt${QT_PKG_VER}/bin:${PATH}
 USER 1027
 RUN conan install boost/1.73.0@ -s compiler.libcxx=libstdc++11 --build=missing && \
     conan install catch2/2.13.0@ -s compiler.libcxx=libstdc++11 --build=missing && \


### PR DESCRIPTION
This is in preparation to have a legal AppImage when Ubuntu 16.04 is deprecated in April 2021. As stated in [AppImage's
documentation](https://docs.appimage.org/packaging-guide/distribution.html#appimagehub), to distribute yuzu on [AppImageHub](https://appimage.github.io/), an AppImage needs to compatible with the oldest still supported release of Ubuntu, which will be 18.04 in April.

Beyond making AppImages, this brings a number of other changes:
- The needed CMake, GCC, and Qt versions are now variables at the top of the Dockerfile.
- The dependencies list is sorted lexicographically.
- Added package `file`, required for the Qt linuxdeploy plugin, thus superseding #23.
- Added package `software-properties-common`, required to use `add-apt-repository`.
- Added package `python3-setuptools`, a dependency of `python3-pip` that somehow isn't installed with it by default.
- Added package `unzip` in order to extract `glslangValidator`.
- Removed package `python` as yuzu no longer uses Unicorn, thus Python 2 was no longer required.
- Moved installing GCC, Qt, FFmpeg, and SDL2 from the main Ubuntu repositories to updated launchpad repositories.
- Removed packages `cmake` and `glslang-tools`, instead opting to download and install them from their upstream repositories.
  - In the case of `glslang-tools`, Ubuntu does not have any equivalent package for Bionic.

This does not upgrade any package versions. This only brings Ubuntu 18.04 roughly to parity with the current 20.04 container. Once an AppImage is in action, we can upgrade the GCC and Qt versions to our heart's content (up to GCC 11 and Qt 5.15.2). Until then, it should be said **Mainline builds are not compatible with Ubuntu versions below 20.04 despite using 18.04 to build yuzu**. We need an AppImage to make yuzu compatible with older distro releases, and we need an AppImage to make yuzu compatible with current releases if we upgrade Qt and/or GCC.

Another note is that the Qt version here is being downgraded from 5.12.8 to 5.12.6. The Qt launchpad PPA used here did not release usable `qt512webengine` packages for 5.12.8 nor 5.12.7, and since upgrading to 5.12.10 would break compatibility with wild Ubuntu 20.04 installs, a downgrade is necessary. Hopefully this is a temporary change during our transition to 5.15.2.

Massive thank you to @AniLeo from RPCS3 for telling me about updated GCC and Qt launchpad PPAs.