### PR TITLE
linux-fresh: Add package nasm

### DIFF
--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -20,6 +20,7 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     libssl-dev \
     libzip-dev \
     libzstd-dev \
+    nasm \
     ninja-build \
     python3-pip \
     python3-setuptools \


### PR DESCRIPTION
Adds nasm to linux-fresh so that FFmpeg can be compiled. ~~Removes mingw-w64-ffmpeg from linux-mingw to prevent packaging unused libraries with yuzu.~~ Holding off on mingw-w64-ffmpeg changes to avoid breaking things for now. I can roll that into a larger cleanup PR for linux-mingw later.