### PR TITLE
fresh: Add hidapi 0.10.1 from ext-linux-bin

### DIFF
--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -13,6 +13,8 @@ ENV UBUNTU_VER=bionic
 RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     apt-get update && apt-get -y full-upgrade && \
     apt-get install --no-install-recommends -y \
+    autoconf \
+    automake \
     build-essential \
     ccache \
     file \
@@ -21,6 +23,8 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     liblz4-dev \
     libopus-dev \
     libssl-dev \
+    libtool \
+    libusb-1.0-0-dev \
     libzip-dev \
     libzstd-dev \
     nasm \
@@ -84,6 +88,13 @@ RUN cd /tmp && \
     chown -R root:root boost_1_75_0/ && \
     cp -rv boost_1_75_0/include boost_1_75_0/lib /usr && \
     rm -rf boost*
+# Install hidapi 0.10.1 from yuzu-emu/ext-linux-bin
+RUN cd /tmp && \
+    wget https://github.com/yuzu-emu/ext-linux-bin/raw/main/hidapi/hidapi_0_10_1.tar.xz &&\
+    tar xvf hidapi_0_10_1.tar.xz && \
+    chown -R root:root hidapi/ && \
+    cp -rv hidapi/include hidapi/lib hidapi/share /usr && \
+    rm -rf hidapi*
 # Setup paths for Qt binaries
 ENV LD_LIBRARY_PATH=/opt/qt${QT_PKG_VER}/lib:${LD_LIBRARY_PATH}
 ENV PATH=/opt/qt${QT_PKG_VER}/bin:${PATH}

--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -89,6 +89,3 @@ ENV LD_LIBRARY_PATH=/opt/qt${QT_PKG_VER}/lib:${LD_LIBRARY_PATH}
 ENV PATH=/opt/qt${QT_PKG_VER}/bin:${PATH}
 USER 1027
 COPY --chown=yuzu:yuzu settings.yml /home/yuzu/.conan/settings.yml
-RUN conan install catch2/2.13.0@ -s compiler.libcxx=libstdc++11 --build=missing && \
-    conan install fmt/7.1.2@ -s compiler.libcxx=libstdc++11 --build=missing && \
-    conan install nlohmann_json/3.9.1@ -s compiler.libcxx=libstdc++11 --build=missing


### PR DESCRIPTION
libhidapi-dev from Bionic repositories is too old for our needs. Download and install a binary package for hidapi manually from yuzu-emu/ext-linux-bin.

This adds a number of packages required to compile hidapi. Needed for producing new hidapi packages in the future.

Lastly, remove Conan package installation at this stage: CMake will just download them again when we build yuzu, so no point in doing it twice.