### PR TITLE
mingw: Delete 32 bit binaries and fix container

### DIFF
--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -17,13 +17,11 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && mkdir -p /tmp/pkgs && \
     glslang \
     python-pip \
     python \
-    python2 \
     ccache \
     p7zip \
     cmake \
     ninja \
     mingw-w64-boost \
-    mingw-w64-ffmpeg \
     mingw-w64-gcc \
     mingw-w64-lz4 \
     mingw-w64-opus \
@@ -39,7 +37,7 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && mkdir -p /tmp/pkgs && \
     mingw-w64-zstd \
     && \
     pacman -Scc --noconfirm && \
-    rm -rf /usr/share/man/ /tmp/* /var/tmp/
+    rm -rf /usr/share/man/ /tmp/* /var/tmp/ /usr/{i686-w64-mingw32,lib32} /usr/lib/gcc/i686-w64-mingw32
 
 # Setup extra mingw work arounds
 RUN pip3 install pefile

--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -1,5 +1,10 @@
 FROM archlinux:latest
 MAINTAINER yuzu
+# Workaround for Arch Linux Docker image failing to build
+# From https://stackoverflow.com/questions/66154574
+RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst && \
+    curl -LO "https://repo.archlinuxcn.org/x86_64/$patched_glibc" && \
+    bsdtar -C / -xvf "$patched_glibc"
 # Add mingw-repo "ownstuff" is a AUR with an up to date mingw64
 # Runs pacman -Syu twice in order to work around pacman issues where the first run only updates the current distro packages
 # and the second run actually pulls the updates from the repos.


### PR DESCRIPTION
We don't use them, no reason to keep them. Removes mingw-w64-ffmpeg -- it never worked, and we no longer use it. And we don't use python2 any more.

In addition, apply a fix to the container: Dockerhub's old version of Docker has an issue that causes pacman to fail. Based on https://github.com/lxqt/lxqt-panel/pull/1562

Saves about 2.3 GB from the finished container.