### PR TITLE
linux-fresh: update base image to use Qt 5.15

### DIFF
--- a/linux-clang-format/Dockerfile
+++ b/linux-clang-format/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:20.04
-MAINTAINER yuzu
+LABEL maintainer="yuzu"
 # Create a user account yuzu (UID 1027) that the container will run as
 RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     apt-get update && apt-get -y full-upgrade && \

--- a/linux-flatpak/Dockerfile
+++ b/linux-flatpak/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:20.04
-MAINTAINER yuzu
+LABEL maintainer="yuzu"
 RUN useradd -m -u 1027 -s /bin/bash yuzu && DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get -y full-upgrade \
     && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
@@ -12,5 +12,5 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && DEBIAN_FRONTEND=noninteractive apt-g
         sshfs fuse elfutils \
     && apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log \
     && flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo \
-    && flatpak install -v -y flathub org.kde.Platform//5.13 org.kde.Sdk//5.13
+    && flatpak install -v -y flathub org.kde.Platform//5.15 org.kde.Sdk//5.15
 USER 1027

--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -1,12 +1,12 @@
 FROM ubuntu:18.04
-MAINTAINER yuzu
+LABEL maintainer="yuzu"
 
 ENV CLANG_VER=12
 ENV CMAKE_VER=3.16.3
 ENV DEBIAN_FRONTEND=noninteractive
 ENV GCC_VER=10
-ENV QT_PKG_VER=512
-ENV QT_VER=5.12.6
+ENV QT_PKG_VER=515
+ENV QT_VER=5.15.2
 ENV UBUNTU_VER=bionic
 
 # Create a user account yuzu (UID 1027) that the container will run as

--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -1,5 +1,5 @@
 FROM archlinux:latest
-MAINTAINER yuzu
+LABEL maintainer="yuzu"
 # Workaround for Arch Linux Docker image failing to build
 # From https://stackoverflow.com/questions/66154574
 RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst && \

--- a/linux-transifex/Dockerfile
+++ b/linux-transifex/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine
-MAINTAINER yuzu
+LABEL maintainer="yuzu"
 RUN adduser -u 1027 -D -s /bin/bash yuzu && \
     apk update && apk add build-base \
     py3-pip \


### PR DESCRIPTION
- `linux-fresh`: update ~~base image to Ubuntu 20.04~~ Qt 5.15
- Other images: replaced `MAINTAINER` with `LABEL` (new specification)