### PR TITLE
liftinstall: Add liftinstall container script

### DIFF
--- a/linux-liftinstall/Dockerfile
+++ b/linux-liftinstall/Dockerfile
@@ -1,22 +1,24 @@
-FROM debian:stable
-MAINTAINER yuzu
+FROM debian:buster
+LABEL maintainer="yuzu"
 
 # Create a user account yuzu (UID 1027) that the container will run as
-RUN apt-get update && apt-get -y full-upgrade && \
+RUN useradd -m -u 1027 -s /bin/bash yuzu && \
+    apt-get update && apt-get -y full-upgrade && \
     apt-get install --no-install-recommends -y \
+    apt-utils \
     ca-certificates \
+    cargo \
     curl \
     gnupg \
-    apt-utils && \
+    libssl-dev \
+    libwebkit2gtk-4.0-dev \
+    nodejs && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg -o /tmp/pubkey.gpg && \
     apt-key add /tmp/pubkey.gpg && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
     apt-get update && apt-get install --no-install-recommends -y \
-    libwebkit2gtk-4.0-dev \
-    libssl-dev \
-    cargo \
-    nodejs \
     yarn && \
     apt-get clean autoclean && \
     apt-get autoremove --yes && \
     rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log
+USER 1027

--- a/linux-liftinstall/Dockerfile
+++ b/linux-liftinstall/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:stable
+MAINTAINER yuzu
+
+# Create a user account yuzu (UID 1027) that the container will run as
+RUN apt-get update && apt-get -y full-upgrade && \
+    apt-get install --no-install-recommends -y \
+    ca-certificates \
+    curl \
+    gnupg \
+    apt-utils && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg -o /tmp/pubkey.gpg && \
+    apt-key add /tmp/pubkey.gpg && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && apt-get install --no-install-recommends -y \
+    libwebkit2gtk-4.0-dev \
+    libssl-dev \
+    cargo \
+    nodejs \
+    yarn && \
+    apt-get clean autoclean && \
+    apt-get autoremove --yes && \
+    rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log


### PR DESCRIPTION
Creates a Docker container that is minimally capable of building the liftinstall for Linux.

Note that it is not strictly necessary to push a build of this container to Docker Hub, since I'm not aware of any CI that we do on yuzu-emu/liftinstall. 