### PR TITLE
CI: switch to use GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: 'Yuzu Docker Image CI'
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: ["linux-clang-format", "linux-flatpak", "linux-fresh", "linux-mingw", "linux-transifex"]
+    
+    steps:
+    - uses: actions/checkout@v2
+    - uses: docker/setup-buildx-action@v1
+      name: Setup Docker BuildX system
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      if: (github.ref == 'refs/heads/master') && (github.repository == 'yuzu-emu/build-environments')
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - uses: docker/build-push-action@v2
+      name: Build image
+      with:
+        push: ${{ (github.ref == 'refs/heads/master') && (github.repository == 'yuzu-emu/build-environments') }}
+        context: ${{ matrix.image }}
+        tags: citraemu/build-environments:${{ matrix.image }}


### PR DESCRIPTION
This pull request will migrate the Docker container building infrastructure to GitHub Actions.

Docker Hub now does not provide a free CI option even for FOSS projects now.