### PR TITLE
fresh,mingw: Refresh and update to Qt 5.15.2

### DIFF
--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -5,8 +5,8 @@ ENV CLANG_VER=12
 ENV CMAKE_VER=3.16.3
 ENV DEBIAN_FRONTEND=noninteractive
 ENV GCC_VER=10
-ENV QT_PKG_VER=512
-ENV QT_VER=5.12.6
+ENV QT_PKG_VER=515
+ENV QT_VER=5.15.2
 ENV UBUNTU_VER=bionic
 
 # Create a user account yuzu (UID 1027) that the container will run as
@@ -36,9 +36,9 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     wget \
     zlib1g-dev \
     zsync && \
-    pip3 install conan
+    pip3 install conan && \
 # Install updated versions of FFmpeg, GCC, Qt, and SDL2 from launchpad repositories
-RUN add-apt-repository -y ppa:beineri/opt-qt-${QT_VER}-${UBUNTU_VER} && \
+    add-apt-repository -y ppa:beineri/opt-qt-${QT_VER}-${UBUNTU_VER} && \
     add-apt-repository -y ppa:cybermax-dexter/sdl2-backport && \
     add-apt-repository -y ppa:jonathonf/ffmpeg-4 && \
     add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
@@ -55,17 +55,17 @@ RUN add-apt-repository -y ppa:beineri/opt-qt-${QT_VER}-${UBUNTU_VER} && \
     qt${QT_PKG_VER}wayland \
     qt${QT_PKG_VER}webengine && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VER} ${GCC_VER} && \
-    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VER} ${GCC_VER}
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VER} ${GCC_VER} && \
 # Install clang from apt.llvm.org
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     echo "deb http://apt.llvm.org/${UBUNTU_VER}/ llvm-toolchain-${UBUNTU_VER}-${CLANG_VER} main" >> /etc/apt/sources.list && \
     apt-get update -y && \
     apt-get install --no-install-recommends -y \
     clang-${CLANG_VER} && \
     ln -s $(which clang-${CLANG_VER}) /usr/bin/clang && \
     ln -s $(which clang++-${CLANG_VER}) /usr/bin/clang++ && \
-    dpkg-reconfigure ccache
-RUN apt-get clean autoclean && \
+    dpkg-reconfigure ccache && \
+    apt-get clean autoclean && \
     apt-get autoremove --yes && \
     rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log
 # Install glslangValidator from upstream

--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -1,5 +1,8 @@
 FROM archlinux:latest
 MAINTAINER yuzu
+
+ENV EXT_BIN_URL="https://github.com/yuzu-emu/ext-linux-bin/raw/main/mingw"
+
 # Workaround for Arch Linux Docker image failing to build
 # From https://stackoverflow.com/questions/66154574
 RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst && \
@@ -7,8 +10,8 @@ RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst && \
     bsdtar -C / -xvf "$patched_glibc" && \
     echo 'IgnorePkg = glibc' >> /etc/pacman.conf
 # Add mingw-repo "ownstuff" is a AUR with an up to date mingw64
-# Runs pacman -Syu twice in order to work around pacman issues where the first run only updates the current distro packages
-# and the second run actually pulls the updates from the repos.
+# Runs pacman -Syu twice in order to work around pacman issues where the first run only updates the
+# current distro packages, and the second run actually pulls the updates from the repos.
 RUN useradd -m -u 1027 -s /bin/bash yuzu && mkdir -p /tmp/pkgs && \
     echo "[ownstuff]" >> /etc/pacman.conf && \
     echo "SigLevel = Optional TrustAll" >> /etc/pacman.conf && \
@@ -37,14 +40,14 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && mkdir -p /tmp/pkgs && \
     mingw-w64-zlib \
     && \
     cd /tmp && \
-    wget -q https://github.com/yuzu-emu/ext-linux-bin/raw/main/mingw/mingw-w64-fmt-8.0.0-5-any.pkg.tar.zst && \
-    wget -q https://github.com/yuzu-emu/ext-linux-bin/raw/main/mingw/mingw-w64-qt5-base-5.15.2-1-x86_64.pkg.tar.zst && \
-    wget -q https://github.com/yuzu-emu/ext-linux-bin/raw/main/mingw/mingw-w64-qt5-declarative-5.15.2-1-x86_64.pkg.tar.zst && \
-    wget -q https://github.com/yuzu-emu/ext-linux-bin/raw/main/mingw/mingw-w64-qt5-graphicaleffects-5.15.2-1-any.pkg.tar.zst && \
-    wget -q https://github.com/yuzu-emu/ext-linux-bin/raw/main/mingw/mingw-w64-qt5-multimedia-5.15.2-1-any.pkg.tar.zst && \
-    wget -q https://github.com/yuzu-emu/ext-linux-bin/raw/main/mingw/mingw-w64-qt5-tools-5.15.2-1-x86_64.pkg.tar.zst && \
-    wget -q https://github.com/yuzu-emu/ext-linux-bin/raw/main/mingw/mingw-w64-qt5-winextras-5.15.2-1-any.pkg.tar.zst && \
-    wget -q https://github.com/yuzu-emu/ext-linux-bin/raw/main/mingw/mingw-w64-zstd-1.5.0-1-any.pkg.tar.zst && \
+    wget -q ${EXT_BIN_URL}/mingw-w64-fmt-8.0.0-5-any.pkg.tar.zst && \
+    wget -q ${EXT_BIN_URL}/mingw-w64-qt5-base-5.15.2-1-x86_64.pkg.tar.zst && \
+    wget -q ${EXT_BIN_URL}/mingw-w64-qt5-declarative-5.15.2-1-x86_64.pkg.tar.zst && \
+    wget -q ${EXT_BIN_URL}/mingw-w64-qt5-graphicaleffects-5.15.2-1-any.pkg.tar.zst && \
+    wget -q ${EXT_BIN_URL}/mingw-w64-qt5-multimedia-5.15.2-1-any.pkg.tar.zst && \
+    wget -q ${EXT_BIN_URL}/mingw-w64-qt5-tools-5.15.2-1-x86_64.pkg.tar.zst && \
+    wget -q ${EXT_BIN_URL}/mingw-w64-qt5-winextras-5.15.2-1-any.pkg.tar.zst && \
+    wget -q ${EXT_BIN_URL}/mingw-w64-zstd-1.5.0-1-any.pkg.tar.zst && \
     pacman -U --noconfirm --noprogressbar mingw-w64-{fmt-8.0.0-5-any,qt5-base-5.15.2-1-x86_64,qt5-declarative-5.15.2-1-x86_64,qt5-graphicaleffects-5.15.2-1-any,qt5-multimedia-5.15.2-1-any,qt5-tools-5.15.2-1-x86_64,qt5-winextras-5.15.2-1-any,zstd-1.5.0-1-any}.pkg.tar.zst && \
     pacman -Scc --noconfirm && \
     rm -rf /usr/share/man/ /tmp/* /var/tmp/ /usr/{i686-w64-mingw32,lib32} /usr/lib/gcc/i686-w64-mingw32


### PR DESCRIPTION
Initially intended to just refresh the containers so they can update their root certificates. This also updates linux-fresh to Qt 5.15.2 since EA AppImages are dead in the middle of the sea and I'm tired of waiting on that to get 5.15 out.