### PR TITLE
linux-transifex: Remove user and maintainer directives

### DIFF
--- a/linux-transifex/Dockerfile
+++ b/linux-transifex/Dockerfile
@@ -1,8 +1,6 @@
 FROM debian:buster-slim
-MAINTAINER yuzu
+LABEL maintainer="yuzuemu"
 ENV DEBIAN_FRONTEND=noninteractive
-RUN useradd -m -u 1027 -s /bin/bash yuzu
 RUN apt-get update && apt-get -y full-upgrade
 RUN apt-get install -y git p7zip-full libqt5opengl5-dev qtmultimedia5-dev qttools5-dev qttools5-dev-tools python3-pip cmake
 RUN pip3 install transifex-client
-USER 1027


### PR DESCRIPTION
This fixes the build failing because of the following reasons:
1. GitHub Actions uses its own user inside the container, so the container should not include the USER directive.
2. Newer Docker builder systems (BuilderX) will not accept the MAINTAINER directive.

A huge thanks to @liushuyu for helping me figure this out and providing the explanation.