### PR TITLE
linux-next

### DIFF
--- a/linux-next/Dockerfile
+++ b/linux-next/Dockerfile
@@ -1,0 +1,121 @@
+FROM ubuntu:20.04
+LABEL maintainer="yuzu"
+
+ENV CLANG_VER=13
+ENV CMAKE_VER=3.16.3
+ENV DEBIAN_FRONTEND=noninteractive
+ENV GCC_VER=11
+ENV QT_VER=5.15.2
+ENV UBUNTU_VER=focal
+ENV UBUNTU_NEXT=jammy
+
+RUN apt-get update && apt-get -y full-upgrade && apt-get update && apt-get install -y packagekit
+
+RUN echo "APT::Default-Release \"${UBUNTU_VER}\";" >> /etc/apt/apt.conf.d/01-ubuntu
+
+RUN echo "deb http://archive.ubuntu.com/ubuntu ${UBUNTU_NEXT} main restricted universe multiverse" >> "\n" \
+    >> /etc/apt/sources.list
+
+RUN apt-get update && apt-get install -y -t jammy gcc-11 g++-11
+
+# Create a user account yuzu (UID 1027) that the container will run as
+RUN useradd -m -u 1027 -s /bin/bash yuzu && \
+    apt-get install --allow-downgrades -y -t focal \
+    autoconf \
+    automake \
+    build-essential \
+    ccache \
+    cmake \
+    file \
+    gpg-agent \
+    libxau6=1:1.0.9-0ubuntu1 \
+    libxdmcp6=1:1.1.3-0ubuntu1 \
+    libxau-dev \
+    libxdmcp-dev \
+    libxcb1=1.14-2 \
+    libxcb1-dev \
+    libx11-xcb1 \
+    liblz4-dev \
+    libopus-dev \
+    libssl-dev \
+    libtool \
+    libusb-1.0-0-dev \
+    libzip-dev \
+    libzstd-dev \
+    nasm \
+    ninja-build \
+    python3-pip \
+    python3-setuptools \
+    software-properties-common \
+    unzip \
+    vim \
+    wget \
+    zlib1g-dev \
+    zsync && \
+    # Install updated versions of FFmpeg, GCC, Qt, and SDL2 from launchpad repositories
+    add-apt-repository -y ppa:savoury1/ffmpeg4 && \
+    add-apt-repository -y ppa:savoury1/multimedia && \
+    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+    add-apt-repository -y ppa:git-core/ppa && \
+    apt-get update -y && \
+    apt-get install -y -t focal \
+    git \
+    libgl1 \
+    libglx-dev \
+    libegl1 \
+    libegl-mesa0 \
+    libglx0 \
+    libglx-mesa0 \
+    libgl-dev \
+    libx11-6 \
+    libx11-dev \
+    libx11-dev \
+    libxext6 \
+    libxext-dev \
+    libegl-dev \
+    libgl-dev \
+    libglvnd-dev \
+    libegl1-mesa-dev \
+    libgl1-mesa-dev \
+    libavcodec-dev \
+    libavutil-dev \
+    libsdl2-dev \
+    libswscale-dev \
+    glslang-tools \
+    glslang-dev \
+    libhidapi-dev && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VER} ${GCC_VER} && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VER} ${GCC_VER} && \
+    # Install clang from apt.llvm.org
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+    echo "deb http://apt.llvm.org/${UBUNTU_NEXT}/ llvm-toolchain-${UBUNTU_NEXT}-${CLANG_VER} main" >> "\n" >> /etc/apt/sources.list && \
+    apt-get update -y && \
+    apt-get install -y -t jammy \
+    clang-${CLANG_VER} python3-pip && \
+    ln -s $(which clang-${CLANG_VER}) /usr/bin/clang && \
+    ln -s $(which clang++-${CLANG_VER}) /usr/bin/clang++ && \
+    dpkg-reconfigure ccache && \
+    apt-get clean autoclean && \
+    apt-get autoremove --yes && \
+    rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log
+RUN pip3 install conan
+# Install Boost 1.75.0 from yuzu-emu/ext-linux-bin
+RUN cd /tmp && \
+    wget https://github.com/yuzu-emu/ext-linux-bin/raw/main/boost/boost_1_75_0.tar.xz &&\
+    tar xvf boost_1_75_0.tar.xz && \
+    chown -R root:root boost_1_75_0/ && \
+    cp -rv boost_1_75_0/include boost_1_75_0/lib /usr && \
+    rm -rf boost*
+# Install qt5.15.2 from yuzu-emu/ext-linux-bin
+RUN mkdir /usr/local/Qt5
+RUN cd /tmp && \
+    wget https://github.com/yuzu-emu/ext-linux-bin/raw/main/qt/qt5_5_15_2.tar.xz &&\
+    tar xvf qt5_5_15_2.tar.xz && \
+    chown -R root:root qt5_5_15_2/ && \
+    cp -avR qt5_5_15_2/* /usr/local/Qt5/ && \
+    rm -rf qt*
+# Setup paths for Qt binaries
+ENV LD_LIBRARY_PATH=/usr/local/Qt5/lib:${LD_LIBRARY_PATH}
+ENV PATH=/usr/local/Qt5/bin:${PATH}
+USER 1027
+COPY --chown=yuzu:yuzu settings.yml /home/yuzu/.conan/settings.yml

--- a/linux-next/settings.yml
+++ b/linux-next/settings.yml
@@ -1,0 +1,133 @@
+
+# Only for cross building, 'os_build/arch_build' is the system that runs Conan
+os_build: [Windows, WindowsStore, Linux, Macos, FreeBSD, SunOS, AIX]
+arch_build: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, sh4le, e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7]
+
+# Only for building cross compilation tools, 'os_target/arch_target' is the system for
+# which the tools generate code
+os_target: [Windows, Linux, Macos, Android, iOS, watchOS, tvOS, FreeBSD, SunOS, AIX, Arduino, Neutrino]
+arch_target: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le, e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7, xtensalx6, xtensalx106]
+
+# Rest of the settings are "host" settings:
+# - For native building/cross building: Where the library/program will run.
+# - For building cross compilation tools: Where the cross compiler will run.
+os:
+    Windows:
+        subsystem: [None, cygwin, msys, msys2, wsl]
+    WindowsStore:
+        version: ["8.1", "10.0"]
+    WindowsCE:
+        platform: ANY
+        version: ["5.0", "6.0", "7.0", "8.0"]
+    Linux:
+    Macos:
+        version: [None, "10.6", "10.7", "10.8", "10.9", "10.10", "10.11", "10.12", "10.13", "10.14", "10.15", "11.0", "12.0", "13.0"]
+        sdk: [None, "macosx"]
+        subsystem: [None, catalyst]
+    Android:
+        api_level: ANY
+    iOS:
+        version: ["7.0", "7.1", "8.0", "8.1", "8.2", "8.3", "9.0", "9.1", "9.2", "9.3", "10.0", "10.1", "10.2", "10.3",
+                  "11.0", "11.1", "11.2", "11.3", "11.4", "12.0", "12.1", "12.2", "12.3", "12.4",
+                  "13.0", "13.1", "13.2", "13.3", "13.4", "13.5", "13.6", "13.7",
+                  "14.0", "14.1", "14.2", "14.3", "14.4", "14.5", "14.6", "14.7", "14.8", "15.0", "15.1"]
+        sdk: [None, "iphoneos", "iphonesimulator"]
+    watchOS:
+        version: ["4.0", "4.1", "4.2", "4.3", "5.0", "5.1", "5.2", "5.3", "6.0", "6.1", "6.2",
+                  "7.0", "7.1", "7.2", "7.3", "7.4", "7.5", "7.6", "8.0", "8.1"]
+        sdk: [None, "watchos", "watchsimulator"]
+    tvOS:
+        version: ["11.0", "11.1", "11.2", "11.3", "11.4", "12.0", "12.1", "12.2", "12.3", "12.4",
+                  "13.0", "13.2", "13.3", "13.4", "14.0", "14.2", "14.3", "14.4", "14.5", "14.6", "14.7",
+                  "15.0", "15.1"]
+        sdk: [None, "appletvos", "appletvsimulator"]
+    FreeBSD:
+    SunOS:
+    AIX:
+    Arduino:
+        board: ANY
+    Emscripten:
+    Neutrino:
+        version: ["6.4", "6.5", "6.6", "7.0", "7.1"]
+    baremetal:
+arch: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le, e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7, xtensalx6, xtensalx106]
+compiler:
+    sun-cc:
+        version: ["5.10", "5.11", "5.12", "5.13", "5.14", "5.15"]
+        threads: [None, posix]
+        libcxx: [libCstd, libstdcxx, libstlport, libstdc++]
+    gcc: &gcc
+        version: ["4.1", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9",
+                  "5", "5.1", "5.2", "5.3", "5.4", "5.5",
+                  "6", "6.1", "6.2", "6.3", "6.4", "6.5",
+                  "7", "7.1", "7.2", "7.3", "7.4", "7.5",
+                  "8", "8.1", "8.2", "8.3", "8.4",
+                  "9", "9.1", "9.2", "9.3",
+                  "10", "10.1", "10.2", "10.3",
+                  "11", "11.1", "11.2"]
+        libcxx: [libstdc++, libstdc++11]
+        threads: [None, posix, win32] #  Windows MinGW
+        exception: [None, dwarf2, sjlj, seh] # Windows MinGW
+        cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
+    Visual Studio: &visual_studio
+        runtime: [MD, MT, MTd, MDd]
+        version: ["8", "9", "10", "11", "12", "14", "15", "16", "17"]
+        toolset: [None, v90, v100, v110, v110_xp, v120, v120_xp,
+                  v140, v140_xp, v140_clang_c2, LLVM-vs2012, LLVM-vs2012_xp,
+                  LLVM-vs2013, LLVM-vs2013_xp, LLVM-vs2014, LLVM-vs2014_xp,
+                  LLVM-vs2017, LLVM-vs2017_xp, v141, v141_xp, v141_clang_c2, v142,
+                  llvm, ClangCL, v143]
+        cppstd: [None, 14, 17, 20, 23]
+    msvc:
+        version: [190, 191, 192, 193]
+        update: [None, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        runtime: [static, dynamic]
+        runtime_type: [Debug, Release]
+        cppstd: [14, 17, 20, 23]
+    clang:
+        version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
+                  "5.0", "6.0", "7.0", "7.1",
+                  "8", "9", "10", "11", "12", "13"]
+        libcxx: [None, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
+        cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
+        runtime: [None, MD, MT, MTd, MDd]
+    apple-clang: &apple_clang
+        version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0", "12.0", "13.0"]
+        libcxx: [libstdc++, libc++]
+        cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
+    intel:
+        version: ["11", "12", "13", "14", "15", "16", "17", "18", "19", "19.1"]
+        update: [None, ANY]
+        base:
+            gcc:
+                <<: *gcc
+                threads: [None]
+                exception: [None]
+            Visual Studio:
+                <<: *visual_studio
+            apple-clang:
+                <<: *apple_clang
+    intel-cc:
+        version: ["2021.1", "2021.2", "2021.3"]
+        update: [None, ANY]
+        mode: ["icx", "classic", "dpcpp"]
+        libcxx: [None, libstdc++, libstdc++11, libc++]
+        cppstd: [None, 98, gnu98, 03, gnu03, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
+        runtime: [None, static, dynamic]
+        runtime_type: [None, Debug, Release]
+    qcc:
+        version: ["4.4", "5.4", "8.3"]
+        libcxx: [cxx, gpp, cpp, cpp-ne, accp, acpp-ne, ecpp, ecpp-ne]
+        cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17]
+    mcst-lcc:
+        version: ["1.19", "1.20", "1.21", "1.22", "1.23", "1.24", "1.25"]
+        base:
+            gcc:
+                <<: *gcc
+                threads: [None]
+                exceptions: [None]
+
+build_type: [None, Debug, Release, RelWithDebInfo, MinSizeRel]
+
+
+cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]  # Deprecated, use compiler.cppstd


### PR DESCRIPTION
Tried to get 18.04 to work with 22.04 packages and was not successful. 
So this is going to be my POC for GCC11.2:
- Ubuntu 20.04 -- base image
- Ubnutu 22.04 -- gcc-11.2 && g++-11.2 && clang-13 && pip3
- Qt5 from yuzu-emu/ext-linux-bin

Qt6 can easily be brought in when ready

Tested build of yuzu @ [16b7fd7](https://github.com/yuzu-emu/yuzu/commit/16b7fd71a0b9e8879ba603b325d814ff4640e697) -- Working

Requires a fix for: [8295](https://github.com/yuzu-emu/yuzu/pull/8295)