### PR TITLE
linux-fresh: Update to Clang 14, GCC 11, and misceallaneous

### DIFF
--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="yuzu"
 ENV CLANG_VER=14
 ENV CMAKE_VER=3.16.9
 ENV DEBIAN_FRONTEND=noninteractive
-ENV GCC_VER=11
+ENV GCC_VER=11.3.0
 ENV QT_PKG_VER=515
 ENV QT_VER=5.15.2
 ENV UBUNTU_VER=bionic
@@ -42,7 +42,7 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     zlib1g-dev \
     zsync && \
     pip3 install conan && \
-# Install updated versions of FFmpeg, GCC, Qt, and SDL2 from launchpad repositories
+# Install updated versions of glslang, git, and Qt from launchpad repositories
     add-apt-repository -y ppa:beineri/opt-qt-${QT_VER}-${UBUNTU_VER} && \
     add-apt-repository -y ppa:savoury1/graphics && \
     add-apt-repository -y ppa:savoury1/multimedia && \
@@ -51,8 +51,6 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     add-apt-repository -y ppa:git-core/ppa && \
     apt-get update -y && \
     apt-get install --no-install-recommends -y \
-    g++-${GCC_VER} \
-    gcc-${GCC_VER} \
     git \
     glslang-dev \
     glslang-tools \
@@ -61,8 +59,6 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     qt${QT_PKG_VER}tools \
     qt${QT_PKG_VER}wayland \
     qt${QT_PKG_VER}webengine && \
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VER} ${GCC_VER} && \
-    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VER} ${GCC_VER} && \
 # Install clang from apt.llvm.org
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     echo "deb http://apt.llvm.org/${UBUNTU_VER}/ llvm-toolchain-${UBUNTU_VER}-${CLANG_VER} main" >> /etc/apt/sources.list && \
@@ -94,6 +90,24 @@ RUN cd /tmp && \
     chown -R root:root boost-1_79_0/ && \
     cp -rv boost-1_79_0/usr / && \
     rm -rf boost*
+
+# Install GCC from yuzu-emu/ext-linux-bin
+RUN cd /tmp && \
+    wget --no-verbose \
+        https://github.com/yuzu-emu/ext-linux-bin/raw/main/gcc/gcc-${GCC_VER}-ubuntu.tar.xz.aa \
+        https://github.com/yuzu-emu/ext-linux-bin/raw/main/gcc/gcc-${GCC_VER}-ubuntu.tar.xz.ab \
+        https://github.com/yuzu-emu/ext-linux-bin/raw/main/gcc/gcc-${GCC_VER}-ubuntu.tar.xz.ac && \
+    cat gcc-${GCC_VER}-ubuntu.tar.xz.* | tar xJ && \
+    cp -rv gcc-${GCC_VER}/usr / && \
+    rm -rf /tmp/gcc* && \
+# Use updated libstdc++ and libgcc_s on the container from GCC 11
+    rm -v /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /lib/x86_64-linux-gnu/libgcc_s.so.1 && \
+    ln -sv /usr/local/lib64/libstdc++.so.6.0.29 /usr/lib/x86_64-linux-gnu/libstdc++.so.6 && \
+    ln -sv /usr/local/lib64/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1 && \
+# Help Clang find the updated GCC C++ version
+    ln -sv /usr/local/include/c++/${GCC_VER}/ /usr/include/c++/${GCC_VER} && \
+    ln -sv /usr/local/lib/gcc/x86_64-pc-linux-gnu/${GCC_VER} /usr/lib/gcc/x86_64-linux-gnu/${GCC_VER} && \
+    cp -rv /usr/local/include/c++/${GCC_VER}/x86_64-pc-linux-gnu/* /usr/local/include/c++/${GCC_VER}/
 
 # Setup paths for Qt binaries
 ENV LD_LIBRARY_PATH=/opt/qt${QT_PKG_VER}/lib:${LD_LIBRARY_PATH}

--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -22,13 +22,9 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     file \
     gpg-agent \
     libfile-mimeinfo-perl \
-    liblz4-dev \
-    libopus-dev \
     libssl-dev \
     libtool \
-    libusb-1.0-0-dev \
     libzip-dev \
-    libzstd-dev \
     nasm \
     ninja-build \
     python3-pip \
@@ -52,7 +48,6 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     git \
     libavcodec-dev \
     libavutil-dev \
-    libsdl2-dev \
     libswscale-dev \
     glslang-tools \
     glslang-dev \

--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -22,14 +22,18 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     file \
     gpg-agent \
     libfile-mimeinfo-perl \
+    libglu1-mesa-dev \
+    libpulse-dev \
     libssl-dev \
     libtool \
     libudev-dev \
     libva-dev \
     libwayland-dev \
     libzip-dev \
+    mesa-common-dev \
     nasm \
     ninja-build \
+    pkg-config \
     python3-pip \
     python3-setuptools \
     software-properties-common \
@@ -64,8 +68,9 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     echo "deb http://apt.llvm.org/${UBUNTU_VER}/ llvm-toolchain-${UBUNTU_VER}-${CLANG_VER} main" >> /etc/apt/sources.list && \
     apt-get update -y && \
     apt-get install --no-install-recommends -y \
-    clang-${CLANG_VER} && \
-    lld-${CLANG_VER} && \
+    clang-${CLANG_VER} \
+    lld-${CLANG_VER} \
+    llvm-${CLANG_VER} \
     llvm-${CLANG_VER}-linker-tools && \
     ln -s $(which clang-${CLANG_VER}) /usr/bin/clang && \
     ln -s $(which clang++-${CLANG_VER}) /usr/bin/clang++ && \
@@ -73,6 +78,7 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     apt-get clean autoclean && \
     apt-get autoremove --yes && \
     rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log
+
 # Install CMake from upstream
 # yuzu requires CMake version 3.15, however Ubuntu only provides 3.10 to Bionic.
 RUN cd /tmp && \
@@ -80,6 +86,7 @@ RUN cd /tmp && \
     tar xvf cmake-${CMAKE_VER}-Linux-x86_64.tar.gz && \
     cp -rv cmake-${CMAKE_VER}-Linux-x86_64/* /usr && \
     rm -rf cmake-*
+
 # Install Boost 1.75.0 from yuzu-emu/ext-linux-bin
 RUN cd /tmp && \
     wget https://github.com/yuzu-emu/ext-linux-bin/raw/main/boost/boost_1_75_0.tar.xz &&\
@@ -87,8 +94,15 @@ RUN cd /tmp && \
     chown -R root:root boost_1_75_0/ && \
     cp -rv boost_1_75_0/include boost_1_75_0/lib /usr && \
     rm -rf boost*
+    
 # Setup paths for Qt binaries
 ENV LD_LIBRARY_PATH=/opt/qt${QT_PKG_VER}/lib:${LD_LIBRARY_PATH}
 ENV PATH=/opt/qt${QT_PKG_VER}/bin:${PATH}
+
+# Fix GCC 11 <-> Qt 5.15 issue
+COPY qtconcurrentthreadengine.patch /opt/qt515/qtconcurrentthreadengine.patch
+RUN patch /opt/qt515/include/QtConcurrent/qtconcurrentthreadengine.h /opt/qt515/qtconcurrentthreadengine.patch && \
+    rm /opt/qt515/qtconcurrentthreadengine.patch
+
 USER 1027
 COPY --chown=yuzu:yuzu settings.yml /home/yuzu/.conan/settings.yml

--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:18.04
 LABEL maintainer="yuzu"
 
-ENV CLANG_VER=12
-ENV CMAKE_VER=3.16.3
+ENV CLANG_VER=14
+ENV CMAKE_VER=3.16.9
 ENV DEBIAN_FRONTEND=noninteractive
-ENV GCC_VER=10
+ENV GCC_VER=11
 ENV QT_PKG_VER=515
 ENV QT_VER=5.15.2
 ENV UBUNTU_VER=bionic
@@ -69,6 +69,8 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     apt-get update -y && \
     apt-get install --no-install-recommends -y \
     clang-${CLANG_VER} && \
+    lld-${CLANG_VER} && \
+    llvm-${CLANG_VER}-linker-tools && \
     ln -s $(which clang-${CLANG_VER}) /usr/bin/clang && \
     ln -s $(which clang++-${CLANG_VER}) /usr/bin/clang++ && \
     dpkg-reconfigure ccache && \

--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -24,6 +24,9 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     libfile-mimeinfo-perl \
     libssl-dev \
     libtool \
+    libudev-dev \
+    libva-dev \
+    libwayland-dev \
     libzip-dev \
     nasm \
     ninja-build \

--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -13,12 +13,15 @@ ENV UBUNTU_VER=bionic
 RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     apt-get update && apt-get -y full-upgrade && \
     apt-get install --no-install-recommends -y \
+    appstream \
     autoconf \
     automake \
     build-essential \
     ccache \
+    desktop-file-utils \
     file \
     gpg-agent \
+    libfile-mimeinfo-perl \
     liblz4-dev \
     libopus-dev \
     libssl-dev \

--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -40,8 +40,9 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     pip3 install conan && \
 # Install updated versions of FFmpeg, GCC, Qt, and SDL2 from launchpad repositories
     add-apt-repository -y ppa:beineri/opt-qt-${QT_VER}-${UBUNTU_VER} && \
-    add-apt-repository -y ppa:savoury1/ffmpeg4 && \
+    add-apt-repository -y ppa:savoury1/graphics && \
     add-apt-repository -y ppa:savoury1/multimedia && \
+    add-apt-repository -y ppa:savoury1/ffmpeg4 && \
     add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
     add-apt-repository -y ppa:git-core/ppa && \
     apt-get update -y && \
@@ -49,11 +50,8 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     g++-${GCC_VER} \
     gcc-${GCC_VER} \
     git \
-    libavcodec-dev \
-    libavutil-dev \
-    libswscale-dev \
-    glslang-tools \
     glslang-dev \
+    glslang-tools \
     libhidapi-dev \
     qt${QT_PKG_VER}base \
     qt${QT_PKG_VER}tools \

--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -82,19 +82,19 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
 # Install CMake from upstream
 # yuzu requires CMake version 3.15, however Ubuntu only provides 3.10 to Bionic.
 RUN cd /tmp && \
-    wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-Linux-x86_64.tar.gz && \
+    wget --no-verbose https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-Linux-x86_64.tar.gz && \
     tar xvf cmake-${CMAKE_VER}-Linux-x86_64.tar.gz && \
     cp -rv cmake-${CMAKE_VER}-Linux-x86_64/* /usr && \
     rm -rf cmake-*
 
-# Install Boost 1.75.0 from yuzu-emu/ext-linux-bin
+# Install Boost 1.79.0 from yuzu-emu/ext-linux-bin
 RUN cd /tmp && \
-    wget https://github.com/yuzu-emu/ext-linux-bin/raw/main/boost/boost_1_75_0.tar.xz &&\
-    tar xvf boost_1_75_0.tar.xz && \
-    chown -R root:root boost_1_75_0/ && \
-    cp -rv boost_1_75_0/include boost_1_75_0/lib /usr && \
+    wget --no-verbose https://github.com/yuzu-emu/ext-linux-bin/raw/main/boost/boost-1_79_0.tar.xz && \
+    tar xvf boost-1_79_0.tar.xz && \
+    chown -R root:root boost-1_79_0/ && \
+    cp -rv boost-1_79_0/usr / && \
     rm -rf boost*
-    
+
 # Setup paths for Qt binaries
 ENV LD_LIBRARY_PATH=/opt/qt${QT_PKG_VER}/lib:${LD_LIBRARY_PATH}
 ENV PATH=/opt/qt${QT_PKG_VER}/bin:${PATH}

--- a/linux-fresh/qtconcurrentthreadengine.patch
+++ b/linux-fresh/qtconcurrentthreadengine.patch
@@ -1,0 +1,7 @@
+250,251c250,251
+<     ThreadEngineStarter<void>(ThreadEngine<void> *_threadEngine)
+<     :ThreadEngineStarterBase<void>(_threadEngine) {}
+---
+>     ThreadEngineStarter(ThreadEngine<void> *_threadEngine)
+>         : ThreadEngineStarterBase<void>(_threadEngine) {}
+

--- a/linux-fresh/settings.yml
+++ b/linux-fresh/settings.yml
@@ -87,7 +87,7 @@ compiler:
     clang:
         version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
                   "5.0", "6.0", "7.0", "7.1",
-                  "8", "9", "10", "11", "12", "13"]
+                  "8", "9", "10", "11", "12", "13", "14"]
         libcxx: [None, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
         runtime: [None, MD, MT, MTd, MDd]


### PR DESCRIPTION
The intention was to get Clang 14 and GCC 11 going, and AppImage verification tools on it, but I ended up cleaning quite a bit more than that.

Beyond those mentioned, this:
- removes some packages that were too old to build yuzu with,
- removes FFmpeg packages since using it breaks the AppImage,
- installs tools needed to build yuzu with [Polly](https://polly.llvm.org) and possibly [ThinLTO](https://clang.llvm.org/docs/ThinLTO.html) (Mainline would probably timeout with LTO, though),
- fixes savoury1 PPAs so that glslang would install once again,
- [patches](https://codereview.qt-project.org/c/qt/qtbase/+/339417/2/src/concurrent/qtconcurrentthreadengine.h) the Qt 5.15 header that causes GCC 11 build issues,
- and updates Boost to 1.79.0.