### PR TITLE
mingw: Clang preparation

### DIFF
--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -1,8 +1,6 @@
 FROM archlinux:latest
 LABEL maintainer="yuzu"
 
-ENV EXT_BIN_URL="https://github.com/yuzu-emu/ext-linux-bin/raw/main/mingw"
-
 # Add mingw-repo "ownstuff" is a AUR with an up to date mingw64
 # Runs pacman -Syu twice in order to work around pacman issues where the first run only updates the
 # current distro packages, and the second run actually pulls the updates from the repos.
@@ -14,6 +12,10 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && mkdir -p /tmp/pkgs && \
     pacman -Syu --noconfirm && \
     pacman -S --needed --noconfirm --noprogressbar \
     base-devel \
+    clang \
+    polly \
+    lld \
+    sudo \
     gnupg \
     wget \
     git \
@@ -26,23 +28,21 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && mkdir -p /tmp/pkgs && \
     ninja \
     mingw-w64-boost \
     mingw-w64-gcc \
+    mingw-w64-libusb \
     mingw-w64-lz4 \
     mingw-w64-opus \
+    mingw-w64-qt5-base \
+    mingw-w64-qt5-declarative \
+    mingw-w64-qt5-graphicaleffects \
+    mingw-w64-qt5-multimedia \
+    mingw-w64-qt5-tools \
+    mingw-w64-qt5-winextras \
     mingw-w64-sdl2 \
     mingw-w64-tools \
     mingw-w64-winpthreads \
     mingw-w64-zlib \
+    mingw-w64-zstd \
     && \
-    cd /tmp && \
-    wget -q ${EXT_BIN_URL}/mingw-w64-fmt-8.0.0-5-any.pkg.tar.zst && \
-    wget -q ${EXT_BIN_URL}/mingw-w64-qt5-base-5.15.2-1-x86_64.pkg.tar.zst && \
-    wget -q ${EXT_BIN_URL}/mingw-w64-qt5-declarative-5.15.2-1-x86_64.pkg.tar.zst && \
-    wget -q ${EXT_BIN_URL}/mingw-w64-qt5-graphicaleffects-5.15.2-1-any.pkg.tar.zst && \
-    wget -q ${EXT_BIN_URL}/mingw-w64-qt5-multimedia-5.15.2-1-any.pkg.tar.zst && \
-    wget -q ${EXT_BIN_URL}/mingw-w64-qt5-tools-5.15.2-1-x86_64.pkg.tar.zst && \
-    wget -q ${EXT_BIN_URL}/mingw-w64-qt5-winextras-5.15.2-1-any.pkg.tar.zst && \
-    wget -q ${EXT_BIN_URL}/mingw-w64-zstd-1.5.0-1-any.pkg.tar.zst && \
-    pacman -U --noconfirm --noprogressbar mingw-w64-{fmt-8.0.0-5-any,qt5-base-5.15.2-1-x86_64,qt5-declarative-5.15.2-1-x86_64,qt5-graphicaleffects-5.15.2-1-any,qt5-multimedia-5.15.2-1-any,qt5-tools-5.15.2-1-x86_64,qt5-winextras-5.15.2-1-any,zstd-1.5.0-1-any}.pkg.tar.zst && \
     pacman -Scc --noconfirm && \
     rm -rf /usr/share/man/ /tmp/* /var/tmp/ /usr/{i686-w64-mingw32,lib32} /usr/lib/gcc/i686-w64-mingw32
 
@@ -50,9 +50,32 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && mkdir -p /tmp/pkgs && \
 RUN pip3 install pefile
 # Compatibility with the old Ubuntu MingW image
 RUN ln -s /usr/x86_64-w64-mingw32/lib/qt /usr/x86_64-w64-mingw32/lib/qt5
+# Get rid of -mwindows from SDL2 CMake configs
+RUN sed -i 's/-mwindows//g' /usr/x86_64-w64-mingw32/lib/cmake/SDL2/sdl2-config.cmake
+# Give yuzu user sudo access for AUR usage
+RUN echo "yuzu ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 # Install conan and add the mingw cross compile as the default profile
 RUN pip3 install conan
 COPY --chown=yuzu:yuzu default /home/yuzu/.conan/profiles/
 COPY --chown=yuzu:yuzu settings.yml /home/yuzu/.conan/settings.yml
 USER 1027
+
+# Build/install small AUR packages
+RUN \
+# mingw-w64-clang -- MinGW wrapper for host clang
+    cd && \
+    git clone https://aur.archlinux.org/mingw-w64-clang-git.git && \
+    cd mingw-w64-clang-git && \
+    makepkg -si --noconfirm --noprogressbar && \
+# mingw-w64-fmt
+    cd && \
+    git clone https://aur.archlinux.org/mingw-w64-fmt.git && \
+    cd mingw-w64-fmt && \
+    # Only build for x86_64
+    sed -i 's/i686-w64-mingw32//g' PKGBUILD && \
+    makepkg -si --noconfirm --noprogressbar --nocheck && \
+# cleanup
+    cd && rm -rf mingw-* && \
+    sudo sed -i 's/yuzu/#yuzu/g' /etc/sudoers
+

--- a/linux-mingw/default
+++ b/linux-mingw/default
@@ -21,6 +21,6 @@ arch=x86_64
 compiler=gcc
 
 # Adjust to the gcc version of your MinGW package
-compiler.version=10.2
+compiler.version=12.1
 compiler.libcxx=libstdc++11
 build_type=Release

--- a/linux-mingw/settings.yml
+++ b/linux-mingw/settings.yml
@@ -64,7 +64,9 @@ compiler:
                   "8", "8.1", "8.2", "8.3", "8.4",
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1", "10.2", "10.3",
-                  "11", "11.1", "11.2"]
+                  "11", "11.1", "11.2",
+                  "12", "12.1",
+                  "13"]
         libcxx: [libstdc++, libstdc++11]
         threads: [None, posix, win32] #  Windows MinGW
         exception: [None, dwarf2, sjlj, seh] # Windows MinGW
@@ -87,7 +89,7 @@ compiler:
     clang:
         version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
                   "5.0", "6.0", "7.0", "7.1",
-                  "8", "9", "10", "11", "12", "13"]
+                  "8", "9", "10", "11", "12", "13", "14", "15"]
         libcxx: [None, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
         runtime: [None, MD, MT, MTd, MDd]


### PR DESCRIPTION
Removes usage of packages from our own repo since the upstream ones are no longer broken. Some packages were AUR-only, so they are now built at the end of the script. Also adds zstd and libusb yuzu requirements.

In addition, adds clang, polly, and lld as well as mingw-w64-clang, a wrapper of Clang for building projects as a Windows target.