### PR TITLE
mingw: Use wclang AUR package

### DIFF
--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -65,8 +65,8 @@ USER 1027
 RUN \
 # mingw-w64-clang -- MinGW wrapper for host clang
     cd && \
-    git clone https://aur.archlinux.org/mingw-w64-clang-git.git && \
-    cd mingw-w64-clang-git && \
+    git clone https://aur.archlinux.org/mingw-w64-wclang-git.git && \
+    cd mingw-w64-wclang-git && \
     makepkg -si --noconfirm --noprogressbar && \
 # mingw-w64-fmt
     cd && \


### PR DESCRIPTION
The clang one was deleted in favor of the this one. For some odd reason, the old one still clones, but we should be moving to `mingw-w64-wclang-git` anyway.