### PR TITLE
fresh,mingw: Deprecate Conan for vcpkg

### DIFF
--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -40,8 +40,13 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     unzip \
     wget \
     zlib1g-dev \
-    zsync && \
-    pip3 install conan && \
+    zsync \
+# vcpkg requirements
+    curl \
+    zip \
+    && \
+# Conan usage is deprecated
+    pip3 install conan && \ 
 # Install updated versions of glslang, git, and Qt from launchpad repositories
     add-apt-repository -y ppa:beineri/opt-qt-${QT_VER}-${UBUNTU_VER} && \
     add-apt-repository -y ppa:savoury1/graphics && \
@@ -119,5 +124,33 @@ COPY qtconcurrentthreadengine.patch /opt/qt515/qtconcurrentthreadengine.patch
 RUN patch /opt/qt515/include/QtConcurrent/qtconcurrentthreadengine.h /opt/qt515/qtconcurrentthreadengine.patch && \
     rm /opt/qt515/qtconcurrentthreadengine.patch
 
+# Install Catch2 manually in order to use older version than vcpkg provides
+RUN cd /tmp && \
+    git clone --depth 1 --branch v2.13.9 https://github.com/catchorg/Catch2.git && \
+    cmake -B build -S Catch2 -G Ninja \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCATCH_USE_VALGRIND=OFF \
+        -DCATCH_BUILD_EXAMPLES=OFF \
+        -DCATCH_ENABLE_COVERAGE=OFF \
+        -DCATCH_ENABLE_WERROR=OFF \
+        -DCATCH_BUILD_TESTING=ON && \
+    ninja -C build install && \
+    rm -rf build Catch2
+
+# Tell CMake to use vcpkg when looking for packages
+ENV VCPKG_TOOLCHAIN_FILE=/home/yuzu/vcpkg/scripts/buildsystems/vcpkg.cmake
+
 USER 1027
+# Conan usage is deprecated
 COPY --chown=yuzu:yuzu settings.yml /home/yuzu/.conan/settings.yml
+# Install vcpkg and required dependencies for yuzu
+RUN cd /home/yuzu &&\
+    git clone --depth 1 https://github.com/Microsoft/vcpkg.git &&\
+    cd vcpkg &&\
+    ./bootstrap-vcpkg.sh &&\
+    ./vcpkg install \
+        fmt \
+        lz4 \
+        nlohmann-json \
+        zlib \
+        zstd

--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -65,8 +65,8 @@ USER 1027
 RUN \
 # mingw-w64-clang -- MinGW wrapper for host clang
     cd && \
-    git clone https://aur.archlinux.org/mingw-w64-clang-git.git && \
-    cd mingw-w64-clang-git && \
+    git clone https://aur.archlinux.org/mingw-w64-wclang-git.git && \
+    cd mingw-w64-wclang-git && \
     makepkg -si --noconfirm --noprogressbar && \
 # mingw-w64-fmt
     cd && \

--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -30,6 +30,7 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && mkdir -p /tmp/pkgs && \
     mingw-w64-gcc \
     mingw-w64-libusb \
     mingw-w64-lz4 \
+    mingw-w64-nlohmann-json \
     mingw-w64-opus \
     mingw-w64-qt5-base \
     mingw-w64-qt5-declarative \
@@ -55,7 +56,7 @@ RUN sed -i 's/-mwindows//g' /usr/x86_64-w64-mingw32/lib/cmake/SDL2/sdl2-config.c
 # Give yuzu user sudo access for AUR usage
 RUN echo "yuzu ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-# Install conan and add the mingw cross compile as the default profile
+# Conan usage is deprecated
 RUN pip3 install conan
 COPY --chown=yuzu:yuzu default /home/yuzu/.conan/profiles/
 COPY --chown=yuzu:yuzu settings.yml /home/yuzu/.conan/settings.yml


### PR DESCRIPTION
Deprecates Conan usage. For fresh, we install vcpkg and all the packages we need from it/Conan. Catch2 must be built and installed separately because Microsoft made it difficult to install a specific version of a package.

In linux-mingw, we just update a comment and install nlohmann-json for MinGW. We were already extremely close to not needing an external package manager here. We do not install vcpkg because it barely works on a Linux host targeting x64-mingw. From https://vcpkg.io/en/docs/users/mingw.html:

> MinGW is not tested as part of vcpkg repository's CI process, so regressions can occur as part of library updates.

Supersedes #53 -- I rolled that change into this PR simply to avoid rebasing.
Supersedes #56 