### PR TITLE
fresh: Specify vcpkg version

### DIFF
--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -7,6 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV GCC_VER=11.3.0
 ENV QT_PKG_VER=515
 ENV QT_VER=5.15.2
+ENV VCPKG_VER=2022.07.25
 ENV UBUNTU_VER=bionic
 
 # Create a user account yuzu (UID 1027) that the container will run as
@@ -145,7 +146,7 @@ USER 1027
 COPY --chown=yuzu:yuzu settings.yml /home/yuzu/.conan/settings.yml
 # Install vcpkg and required dependencies for yuzu
 RUN cd /home/yuzu &&\
-    git clone --depth 1 https://github.com/Microsoft/vcpkg.git &&\
+    git clone --depth 1 --branch ${VCPKG_VER} https://github.com/Microsoft/vcpkg.git &&\
     cd vcpkg &&\
     ./bootstrap-vcpkg.sh &&\
     ./vcpkg install \


### PR DESCRIPTION
Limits vcpkg to installing a specific set of package versions, such as fmt 9.0.0. Prevents it from updating package versions beyond our control.