### PR TITLE
fresh: Update container to Ubuntu focal

### DIFF
--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -77,7 +77,6 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     qt${QT_PKG_VER}tools \
     qt${QT_PKG_VER}wayland \
     qt${QT_PKG_VER}multimedia \
-    qt${QT_PKG_VER}webengine \
     qt${QT_PKG_VER}x11extras && \
 # Install Clang from apt.llvm.org
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \

--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -1,45 +1,62 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL maintainer="yuzu"
 
+ENV BOOST_VER=1_81_0
 ENV CLANG_VER=14
 ENV CMAKE_VER=3.22.6
 ENV DEBIAN_FRONTEND=noninteractive
-ENV GCC_VER=11.3.0
+ENV GCC_VER=12.2.0
+ENV GNU_BIN_VER=2.40
 ENV QT_PKG_VER=515
 ENV QT_VER=5.15.2
-ENV UBUNTU_VER=bionic
+ENV UBUNTU_VER=focal
 
 # Create a user account yuzu (UID 1027) that the container will run as
 RUN useradd -m -u 1027 -s /bin/bash yuzu && \
-    apt-get update && apt-get -y full-upgrade && \
+    apt-get update && \
+    apt-get full-upgrade -y && \
     apt-get install --no-install-recommends -y \
-    appstream \
-    autoconf \
-    automake \
-    build-essential \
-    ccache \
-    desktop-file-utils \
-    file \
-    gpg-agent \
-    libfile-mimeinfo-perl \
-    libglu1-mesa-dev \
-    libpulse-dev \
-    libssl-dev \
-    libtool \
-    libudev-dev \
-    libva-dev \
-    libwayland-dev \
-    libzip-dev \
-    mesa-common-dev \
-    nasm \
-    ninja-build \
-    patchelf \
-    pkg-config \
+    apt-utils \
+    ca-certificates \
+    gnupg \
     software-properties-common \
     unzip \
     wget \
+    xz-utils \
+# yuzu build requirements
+    build-essential \
+    ccache \
+    git \
+    libgl-dev \
+    liblz4-dev \
+    libpulse-dev \
+    libudev-dev \
+    libssl-dev \
+    libtool \
+    libwayland-dev \
+    ninja-build \
+    pkg-config \
     zlib1g-dev \
+# AppImage support
+    appstream \
+    desktop-file-utils \
+    file \
+    libfile-mimeinfo-perl \
+    patchelf \
     zsync \
+# FFmpeg build requirements
+    libdrm-dev \
+    libva-dev \
+    libx11-dev \
+    libxext-dev \
+    nasm \
+# libusb build requirements
+    autoconf \
+    automake \
+    libtool \
+    libudev-dev \
+# apt.llvm.org Clang requirements
+    gpg-agent \
 # vcpkg requirements
     curl \
     zip \
@@ -49,7 +66,6 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     add-apt-repository -y ppa:savoury1/graphics && \
     add-apt-repository -y ppa:savoury1/multimedia && \
     add-apt-repository -y ppa:savoury1/ffmpeg4 && \
-    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
     add-apt-repository -y ppa:git-core/ppa && \
     apt-get update -y && \
     apt-get install --no-install-recommends -y \
@@ -63,7 +79,7 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     qt${QT_PKG_VER}multimedia \
     qt${QT_PKG_VER}webengine \
     qt${QT_PKG_VER}x11extras && \
-# Install clang from apt.llvm.org
+# Install Clang from apt.llvm.org
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     echo "deb http://apt.llvm.org/${UBUNTU_VER}/ llvm-toolchain-${UBUNTU_VER}-${CLANG_VER} main" >> /etc/apt/sources.list && \
     apt-get update -y && \
@@ -80,19 +96,18 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && \
     rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log
 
 # Install CMake from upstream
-# yuzu requires CMake version 3.15, however Ubuntu only provides 3.10 to Bionic.
 RUN cd /tmp && \
     wget --no-verbose https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-x86_64.tar.gz && \
     tar xvf cmake-${CMAKE_VER}-linux-x86_64.tar.gz && \
     cp -rv cmake-${CMAKE_VER}-linux-x86_64/* /usr && \
     rm -rf cmake-*
 
-# Install Boost 1.79.0 from yuzu-emu/ext-linux-bin
+# Install Boost from yuzu-emu/ext-linux-bin
 RUN cd /tmp && \
-    wget --no-verbose https://github.com/yuzu-emu/ext-linux-bin/raw/main/boost/boost-1_79_0.tar.xz && \
-    tar xvf boost-1_79_0.tar.xz && \
-    chown -R root:root boost-1_79_0/ && \
-    cp -rv boost-1_79_0/usr / && \
+    wget --no-verbose https://github.com/yuzu-emu/ext-linux-bin/raw/main/boost/boost-${BOOST_VER}.tar.xz && \
+    tar xvf boost-${BOOST_VER}.tar.xz && \
+    chown -R root:root boost-${BOOST_VER}/ && \
+    cp -rv boost-${BOOST_VER}/usr / && \
     rm -rf boost*
 
 # Install GCC from yuzu-emu/ext-linux-bin
@@ -100,18 +115,27 @@ RUN cd /tmp && \
     wget --no-verbose \
         https://github.com/yuzu-emu/ext-linux-bin/raw/main/gcc/gcc-${GCC_VER}-ubuntu.tar.xz.aa \
         https://github.com/yuzu-emu/ext-linux-bin/raw/main/gcc/gcc-${GCC_VER}-ubuntu.tar.xz.ab \
-        https://github.com/yuzu-emu/ext-linux-bin/raw/main/gcc/gcc-${GCC_VER}-ubuntu.tar.xz.ac && \
+        https://github.com/yuzu-emu/ext-linux-bin/raw/main/gcc/gcc-${GCC_VER}-ubuntu.tar.xz.ac \
+        https://github.com/yuzu-emu/ext-linux-bin/raw/main/gcc/gcc-${GCC_VER}-ubuntu.tar.xz.ad && \
     cat gcc-${GCC_VER}-ubuntu.tar.xz.* | tar xJ && \
     cp -rv gcc-${GCC_VER}/usr / && \
     rm -rf /tmp/gcc* && \
 # Use updated libstdc++ and libgcc_s on the container from GCC 11
     rm -v /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /lib/x86_64-linux-gnu/libgcc_s.so.1 && \
-    ln -sv /usr/local/lib64/libstdc++.so.6.0.29 /usr/lib/x86_64-linux-gnu/libstdc++.so.6 && \
+    ln -sv /usr/local/lib64/libstdc++.so.6.0.30 /usr/lib/x86_64-linux-gnu/libstdc++.so.6 && \
     ln -sv /usr/local/lib64/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1 && \
 # Help Clang find the updated GCC C++ version
     ln -sv /usr/local/include/c++/${GCC_VER}/ /usr/include/c++/${GCC_VER} && \
     ln -sv /usr/local/lib/gcc/x86_64-pc-linux-gnu/${GCC_VER} /usr/lib/gcc/x86_64-linux-gnu/${GCC_VER} && \
     cp -rv /usr/local/include/c++/${GCC_VER}/x86_64-pc-linux-gnu/* /usr/local/include/c++/${GCC_VER}/
+
+# Install GNU binutils from yuzu-emu/ext-linux-bin
+RUN cd /tmp && \
+    wget --no-verbose \
+        https://github.com/yuzu-emu/ext-linux-bin/raw/main/binutils/binutils-${GNU_BIN_VER}-${UBUNTU_VER}.tar.xz && \
+    tar xf binutils-${GNU_BIN_VER}-${UBUNTU_VER}.tar.xz && \
+    cp -rv binutils-${GNU_BIN_VER}-${UBUNTU_VER}/usr / && \
+    rm -rf /tmp/binutils*
 
 # Setup paths for Qt binaries
 ENV LD_LIBRARY_PATH=/opt/qt${QT_PKG_VER}/lib:${LD_LIBRARY_PATH}

--- a/linux-fresh/gcc_build_requirements
+++ b/linux-fresh/gcc_build_requirements
@@ -1,0 +1,7 @@
+
+RUN apt install --no-install-recommends -y \
+    libgmp-dev \
+    libmpfr-dev \
+    libmpc-dev \
+    flex \
+    bison


### PR DESCRIPTION
Requires yuzu-emu/ext-linux-bin#12

Ubuntu bionic loses support next month, so we are getting ahead of it by upgrading to Ubuntu 20.04 (focal) now.

Notable changes include reorganizing the initial swath of packages to indicate where their necessity originated, updating Boost and GCC to their latest versions, and installing the latest version of GNU Binutils.

This was spurred on by yuzu-emu/yuzu#9982 exposing the fact we have a relatively old version of GNU as running on linux-fresh.