### PR TITLE
Install Boost 1.79 for mingw, fresh-arm64

### DIFF
--- a/linux-fresh-arm64/Dockerfile
+++ b/linux-fresh-arm64/Dockerfile
@@ -68,7 +68,7 @@ ENV VCPKG_FORCE_SYSTEM_BINARIES=1
 USER 1027
 # Install vcpkg and required dependencies for yuzu
 RUN cd /home/yuzu &&\
-    git clone --depth 1 https://github.com/Microsoft/vcpkg.git &&\
+    git clone --branch 2022.08.15 --depth 1 https://github.com/Microsoft/vcpkg.git &&\
     cd vcpkg &&\
     ./bootstrap-vcpkg.sh &&\
     ./vcpkg install \

--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -26,7 +26,6 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && mkdir -p /tmp/pkgs && \
     p7zip \
     cmake \
     ninja \
-    mingw-w64-boost \
     mingw-w64-gcc \
     mingw-w64-libusb \
     mingw-w64-lz4 \
@@ -45,6 +44,12 @@ RUN useradd -m -u 1027 -s /bin/bash yuzu && mkdir -p /tmp/pkgs && \
     && \
     pacman -Scc --noconfirm && \
     rm -rf /usr/share/man/ /tmp/* /var/tmp/ /usr/{i686-w64-mingw32,lib32} /usr/lib/gcc/i686-w64-mingw32
+
+# Install Boost from yuzu-emu/ext-linux-bin
+RUN wget --no-verbose \
+        https://github.com/yuzu-emu/ext-linux-bin/raw/main/mingw/mingw-w64-boost-1.79.0-1-any.pkg.tar.zst && \
+    pacman -U --noconfirm mingw-w64-boost-1.79.0-1-any.pkg.tar.zst && \
+    rm mingw-w64-boost-1.79.0-1-any.pkg.tar.zst
 
 # Setup extra mingw work arounds
 RUN pip3 install pefile


### PR DESCRIPTION
Requires yuzu-emu/ext-linux-bin#13

For MinGW, we install a Boost package I generated on my machine using https://aur.archlinux.org/packages/mingw-w64-boost. This is because trying to build the package during container building does not succeed: `mingw-w64-boost` has the build dependency `mingw-w64-wine` which adds considerable bloat to the image.

In fresh-arm64, we pin vcpkg's version to the most recent version before Boost 1.80 was added. This fortunately still includes fmt 9.0.0.