### PR TITLE
transifex: Add libavfilter-dev

### DIFF
--- a/linux-transifex/Dockerfile
+++ b/linux-transifex/Dockerfile
@@ -4,11 +4,34 @@ LABEL maintainer="yuzuemu"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV CMAKE_VER=3.22.6
 
-RUN apt-get update && apt-get -y full-upgrade
-RUN apt-get install -y git p7zip-full libqt5opengl5-dev qtmultimedia5-dev qttools5-dev qttools5-dev-tools \
-    python3-pip cmake libavcodec-dev libavutil-dev libsdl2-dev libswscale-dev liblz4-dev libopus-dev \
-    libssl-dev libtool libusb-1.0-0-dev glslang-tools curl zip unzip
-RUN curl -O -L https://github.com/transifex/cli/releases/latest/download/tx-linux-amd64.tar.gz && tar xf tx-linux-amd64.tar.gz tx && mv tx /usr/bin/tx && rm tx-linux-amd64.tar.gz
+RUN apt-get update && \
+    apt-get -y full-upgrade
+RUN apt-get install -y \
+    cmake \
+    curl \
+    git \
+    glslang-tools \
+    libavcodec-dev \
+    libavutil-dev \
+    liblz4-dev \
+    libopus-dev \
+    libqt5opengl5-dev \
+    libsdl2-dev \
+    libssl-dev \
+    libswscale-dev \
+    libtool \
+    libusb-1.0-0-dev \
+    p7zip-full \
+    python3-pip \
+    qtmultimedia5-dev \
+    qttools5-dev \
+    qttools5-dev-tools \
+    unzip \
+    zip
+RUN curl -O -L https://github.com/transifex/cli/releases/latest/download/tx-linux-amd64.tar.gz && \
+    tar xf tx-linux-amd64.tar.gz tx && \
+    mv tx /usr/bin/tx && \
+    rm tx-linux-amd64.tar.gz
 
 # Install CMake from upstream
 RUN cd /tmp && \

--- a/linux-transifex/Dockerfile
+++ b/linux-transifex/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get install -y \
     git \
     glslang-tools \
     libavcodec-dev \
+    libavfilter-dev \
     libavutil-dev \
     liblz4-dev \
     libopus-dev \


### PR DESCRIPTION
Adds the FFmpeg package libavfilter-dev, needed by yuzu-emu/yuzu#10283.

Also moves all the packages and individual commands to their own lines, and sorts the packages alphabetically.